### PR TITLE
Authenticate with token

### DIFF
--- a/2fa-audit.go
+++ b/2fa-audit.go
@@ -33,13 +33,7 @@ func main() {
   client := octokit.NewClient(nil)
   req, _ := client.NewRequest(url.String())
   var members []Member
-  // result := client.get(url, &members)
   req.Get(&members)
-
-  // if result.HasError() {
-  //   fmt.Println("Error: ", err)
-  //   return
-  // }
 
   if len(members) == 0 { fmt.Println("No users have 2fa disabled.") }
   for i:=0; i<len(members); i++ {

--- a/2fa-audit.go
+++ b/2fa-audit.go
@@ -17,18 +17,14 @@ func main() {
   }
 
   orgName := os.Args[1]
-  fmt.Printf("Org Name is: %v", orgName)
 
   memberURL := octokit.Hyperlink("/orgs/{org}/members{?filter}") // type,page,per_page,sort
   url, err := memberURL.Expand(octokit.M{"org": orgName, "filter": "2fa_disabled"})
-
-  fmt.Println("What is URL: " + url.String())
 
   if err != nil {
     fmt.Println("There was an error: ", err)
     return
   }
-  fmt.Printf("URL is: %v\n", url)
 
   client := octokit.NewClient(nil)
   req, _ := client.NewRequest(url.String())


### PR DESCRIPTION
Our previous experiment stopped short of working: the org members API 2fa filter needs authentication and only works if auth'd as a member of the org. So, trying that here. And it seems to work now, including pagination.

```
2fa-audit -token <token> <orgname>
<prints lots of usernames>
```

To test this, you'll need a user access token and an org name. I'm using `githubschool` -- it's one org I know with a guaranteed mix of 2fa/non-2fa users (eg, githubteacher and githubstudent are non-2fa, but I'm a member and I'm using 2fa, so...)

---

@nathos @brntbeer since scheduling pairing was challenging (calendar is hard), I'm going back to ye olde PR review process, since I figure we're still interested in evaluating Go as a potential member of our toolset -- someone want to :eyes: and give this a :+1: -- then we can do some of that evaluation.
